### PR TITLE
Throw an exception instead of a fatal error for the Zip extension.

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -34,6 +34,10 @@ class NewCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (! class_exists('ZipArchive')) {
+            throw new RuntimeException('The Zip extension is missing on your system. Please install it and try again.');
+        }
+
         $this->verifyApplicationDoesntExist(
             $directory = getcwd().'/'.$input->getArgument('name'),
             $output


### PR DESCRIPTION
Before this fix, creating a new application throws a fatal error if the Zip extension is not installed.