### PR TITLE
[5.8] Add ability to install in the current directory

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -23,7 +23,7 @@ class NewCommand extends Command
         $this
             ->setName('new')
             ->setDescription('Create a new Lumen application.')
-            ->addArgument('name', InputArgument::REQUIRED);
+            ->addArgument('name', InputArgument::OPTIONAL);
     }
 
     /**
@@ -39,9 +39,9 @@ class NewCommand extends Command
             throw new RuntimeException('The Zip PHP extension is not installed. Please install it and try again.');
         }
 
-        $this->verifyApplicationDoesntExist(
-            $directory = getcwd().'/'.$input->getArgument('name')
-        );
+        $directory = ($input->getArgument('name')) ? getcwd().'/'.$input->getArgument('name') : getcwd();
+
+        $this->verifyApplicationDoesntExist($directory);
 
         $output->writeln('<info>Crafting application...</info>');
 
@@ -82,7 +82,7 @@ class NewCommand extends Command
      */
     protected function verifyApplicationDoesntExist($directory)
     {
-        if (is_dir($directory)) {
+        if ((is_dir($directory) || is_file($directory)) && $directory !== getcwd()) {
             throw new RuntimeException('Application already exists!');
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This implements the same code from the [Laravel installer](https://github.com/laravel/installer/blob/576e22d0587ac1b6402500fa94d6f37bd498b3f5/src/NewCommand.php) so that you can run `lumen new` without a `name` argument to install in the current working directory.

Closes #18