### PR TITLE
Added command interruption using ctrl+c in Windows mintty

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -45,6 +45,8 @@ class NewCommand extends Command
 
         $output->writeln('<info>Crafting application...</info>');
 
+        $this->setSignalHandler();
+
         $this->download($zipFile = $this->makeFilename())
              ->extract($zipFile, $directory)
              ->cleanUp($zipFile);
@@ -159,5 +161,36 @@ class NewCommand extends Command
         }
 
         return 'composer';
+    }
+
+    /**
+     * Make it possible to interrupt execution in Windows mintty.
+     *
+     *@return void
+     */
+    protected function setSignalHandler()
+    {
+        if (function_exists('\sapi_windows_set_ctrl_handler')) {
+            // Windows - requires php 7.4
+            \sapi_windows_set_ctrl_handler([$this, 'SignalHandlerWindows']);
+        }
+    }
+
+    /**
+     * Handle CTRL+C / CTRL+break signal on Windows.
+     *
+     * @param  int  $signal
+     * @return void
+     */
+    public function SignalHandlerWindows(int $signal)
+    {
+         switch ($signal) {
+             case PHP_WINDOWS_EVENT_CTRL_C:
+             case PHP_WINDOWS_EVENT_CTRL_BREAK:
+                 exit;
+                 break;
+
+             default:
+         }
     }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -184,13 +184,13 @@ class NewCommand extends Command
      */
     public function SignalHandlerWindows(int $signal)
     {
-         switch ($signal) {
-             case PHP_WINDOWS_EVENT_CTRL_C:
-             case PHP_WINDOWS_EVENT_CTRL_BREAK:
-                 exit;
-                 break;
+        switch ($signal) {
+            case PHP_WINDOWS_EVENT_CTRL_C:
+            case PHP_WINDOWS_EVENT_CTRL_BREAK:
+                exit;
+                break;
 
-             default:
-         }
+            default:
+        }
     }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -166,13 +166,13 @@ class NewCommand extends Command
     /**
      * Make it possible to interrupt execution in Windows mintty.
      *
-     *@return void
+     * @return void
      */
     protected function setSignalHandler()
     {
         if (function_exists('\sapi_windows_set_ctrl_handler')) {
             // Windows - requires php 7.4
-            \sapi_windows_set_ctrl_handler([$this, 'SignalHandlerWindows']);
+            \sapi_windows_set_ctrl_handler([$this, 'handleWindowsSignals']);
         }
     }
 
@@ -182,15 +182,12 @@ class NewCommand extends Command
      * @param  int  $signal
      * @return void
      */
-    public function SignalHandlerWindows(int $signal)
+    public function handleWindowsSignals($signal)
     {
         switch ($signal) {
             case PHP_WINDOWS_EVENT_CTRL_C:
             case PHP_WINDOWS_EVENT_CTRL_BREAK:
                 exit;
-                break;
-
-            default:
         }
     }
 }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -187,7 +187,7 @@ class NewCommand extends Command
         switch ($signal) {
             case PHP_WINDOWS_EVENT_CTRL_C:
             case PHP_WINDOWS_EVENT_CTRL_BREAK:
-                exit;
+                exit(130);
         }
     }
 }


### PR DESCRIPTION
On Windows systems, Git comes installed with Git Bash which uses Mintty to emulate the terminal.

When running `lumen new blog` in Mintty, it's not possible to stop the command with the usual key combination CTRL + c.

This pull request fixes this inconvenience by making it possible to interrupt the command using CTRL + c.

Tested on Windows in cmd.exe, mintty.exe and on Linux, no side-effects detected.

If you accept the pull request, I'll make the same pull request for laravel/laravel-installer.