### PR TITLE
Copy lumen config to installation dir

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -69,6 +69,19 @@ class NewCommand extends Command
             $output->write($line);
         });
 
+        // copy config
+        $commands = [
+            'cp', '-r', $directory.'/vendor/laravel/lumen-framework/config', $directory,
+        ];
+
+        $process = new Process($commands, $directory, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            $process->setTty(true);
+        }
+
+        $process->run();
+
         $output->writeln('<comment>Application ready! Build something amazing.</comment>');
 
         return 0;


### PR DESCRIPTION
I noticed a significant difference between `lumen new blog` and `composer create-project laravel/lumen-framework blog`.

The first one does not create the config directory inside the new blog project while the second one does.

The intend for this pull request is to copy the config to the project so the lumen command behaves the same as composer.

Tested on Windows and Linux.

If the pull request is accepted, I'll make the same change for the laravel installer.